### PR TITLE
Remove `result_only` from request parameters

### DIFF
--- a/lib/ruby-dmm/client.rb
+++ b/lib/ruby-dmm/client.rb
@@ -33,6 +33,7 @@ module DMM
         hash.merge(key.to_sym => value)
       end
 
+      @result_only = !!params.delete(:result_only)  # Set true to get response.result only.
       @params = {
         :api_id       => ENV['DMM_API_ID']        || params[:api_id],       # your own api_id
         :affiliate_id => ENV['DMM_AFFILIATE_ID']  || params[:affiliate_id], # your own affiliate_id
@@ -40,7 +41,6 @@ module DMM
         :version      => DEFAULT_API_VERSION,
         :timestamp    => Time.now.strftime("%F %T"),
         :site         => DEFAULT_SITE,
-        :result_only  => false, # Set true to get response.result only.
       }.merge(params)
     end
 

--- a/lib/ruby-dmm/client/item_list.rb
+++ b/lib/ruby-dmm/client/item_list.rb
@@ -11,7 +11,12 @@ module DMM
         @params[:operation] = OPERATION_ITEM_LIST
         response = get('/', @params)
         item_list = DMM::Response.new(response[:response])
-        @params[:result_only] ? item_list.result : item_list
+
+        if @result_only
+          item_list.result
+        else
+          item_list
+        end
       end
       alias_method :items, :item_list
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -22,5 +22,11 @@ describe DMM::Client do
     it "returns last response" do
       @client.last_response.should_not be_nil
     end
+
+    describe 'request params' do
+      subject { @client.params }
+      it { should_not have_key(:result_only) }
+    end
+
   end
 end


### PR DESCRIPTION
`result_only` is parameter for configuring ruby-dmm.
