### PR TITLE
Add encode_options to DMM::Client

### DIFF
--- a/lib/ruby-dmm/client.rb
+++ b/lib/ruby-dmm/client.rb
@@ -40,6 +40,8 @@ module DMM
         :timestamp    => Time.now.strftime('%F %T'),
         :site         => DEFAULT_SITE,
       }.merge(params)
+
+      @encode_options = params[:encode_options] || {}
     end
 
     def operation(value)
@@ -74,7 +76,7 @@ module DMM
 
     def encode_params!
       @params.each do |_key, value|
-        value.encode!(Encoding::EUC_JP) if value.is_a?(String) && !value.frozen?
+        value.encode!(Encoding::EUC_JP, @encode_options) if value.is_a?(String) && !value.frozen?
       end
     end
   end


### PR DESCRIPTION
`encode_params!` failed and cannot get response,
if keyword has character which is undefined by EUC-JP.

this commit provide a way of avoiding.

example:

``` ruby
    @client = DMM.new(
      api_id: config["api_id"],
      affiliate_id: config["affiliate_id"],
      result_only: true,
      encode_options: {:invalid => :replace, :undef => :replace, :replace => " "}
    )
```

(convert irregular character to whitespace.)

refs. http://rurema.clear-code.com/2.1.0/method/String/i/encode.html
